### PR TITLE
Change tf import to support Tensorflow 2.0.0

### DIFF
--- a/modules/ImageClassifierService/app/predict.py
+++ b/modules/ImageClassifierService/app/predict.py
@@ -1,7 +1,7 @@
 
 from urllib.request import urlopen
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from PIL import Image
 import numpy as np


### PR DESCRIPTION
The `tensorflow:latest-py3` container uses TensorFlow 2.0.0 which does not support `GraphDef()`. This causes the Image Classifier Service container to fail. Changing the import function to `tensorflow.compat.v1` maintains support for TensorFlow <2.0.0 functionality and the container (and the solution) start successfully.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->